### PR TITLE
Adds ApiContext interface and default EmptyApiContext.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ hs_err_pid*
 .classpath
 *.iml
 target
+out

--- a/src/main/java/com/rba/jaxrs/autoconfig/classify/ApiContext.java
+++ b/src/main/java/com/rba/jaxrs/autoconfig/classify/ApiContext.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rba.jaxrs.autoconfig.classify;
+
+/**
+ * An interface for passing context through to the JaxRS server creation.
+ *<p>
+ * Usages may include a role context or indicators such as internal/external or possibly context by subsystems.
+ *</p>
+ * <p>
+ * Supports enabling and disabling the context since there are use cases where context availability may be data driven or
+ * system parameter driven or both.  The transformation of this interface to a jaxrs server path will honor the enabled flag.
+ *</p>
+ * Example Usage:
+ *
+ * <code>
+ *     public enum SubSystemContext implements ApiContext {
+ *         SUBSYSTEM_A("contexta", "subsys.enabled.a"),
+ *         SUBSYSTEM_B("contextb", "subsys.enabled.b");
+ *
+ *         private final String apiContext;
+ *         private final String environmentParam;
+ *
+ *         SybSystemContext(String apiContext, String environmentParam) {
+ *              this.apiContext = apiContext;
+ *              this.environmentParam = environmentParam;
+ *         }
+ *
+ *         public String getApiContext() {
+ *             return apiContext;
+ *         }
+ *
+ *         public boolean isApiContextEnabled() {
+ *             String paramValue = System.getProperty(environmentParam);
+ *             return paramValue == null ? true || Boolean.valueOf(paramValue);
+ *         }
+ *     }
+ * </code>
+ *
+ * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
+ * @since 11 /14/2018
+ * @since 0.1.0
+ */
+public interface ApiContext {
+
+    /**
+     * returns a string representation of a part of the api path.
+     *
+     * @return the api context fragment
+     */
+    String getApiContext();
+
+    /**
+     * Returns if the context fragment is enabled and should be hosted by a jaxrs server.
+     * Defaults to True
+     *
+     * @return the true if this api version is enabled
+     */
+    default boolean isApiContextEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/rba/jaxrs/autoconfig/classify/EmptyApiContext.java
+++ b/src/main/java/com/rba/jaxrs/autoconfig/classify/EmptyApiContext.java
@@ -14,27 +14,31 @@
  * limitations under the License.
  */
 
-package com.rba.jaxrs.autoconfig.version;
+package com.rba.jaxrs.autoconfig.classify;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import com.sun.istack.internal.Nullable;
 
 /**
- * Runs basic validations to ensure the EmptyApiVersion properly meets the ApiVersion expectations and defaults come through.
+ * A default implementation of {@link ApiContext} that provides a null value for api context and is enabled.
  *
  * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
- * @since 11/13/2018
+ * @since 11 /14/2018
+ * @Since 0.1.0
  */
-class EmptyApiVersionUTEST {
+public class EmptyApiContext implements ApiContext {
 
-    @Test
-    void validateApiVersion() {
-        Assertions.assertNull(EmptyApiVersion.EMPTY_API_VERSION.getApiVersion(), "The API Version should always be null");
+    /**
+     * The constant EMPTY_API_CONTEXT.
+     */
+    public static final EmptyApiContext EMPTY_API_CONTEXT = new EmptyApiContext();
+
+    //Private EmptyApiContext constructor since context and enabled can not be changed, force use of the static EMPTY_API_CONTEXT
+    private EmptyApiContext() {}
+
+    @Nullable
+    @Override
+    public String getApiContext() {
+        return null;
     }
 
-    @Test
-    void validateEmptyApiVersionEnabled() {
-        Assertions.assertTrue(EmptyApiVersion.EMPTY_API_VERSION.isApiVersionEnabled(), "This should always be true from the "
-                + "default of the interface");
-    }
 }

--- a/src/main/java/com/rba/jaxrs/autoconfig/version/ApiVersion.java
+++ b/src/main/java/com/rba/jaxrs/autoconfig/version/ApiVersion.java
@@ -17,9 +17,12 @@
 package com.rba.jaxrs.autoconfig.version;
 
 /**
+ * A special {@link com.rba.jaxrs.autoconfig.classify.ApiContext} geared directly towards versioning.  Broken into its own
+ * interface so we can force a single version context to a single endpoint.
+ * <p>
  * Interface that indicates a version segment of an api url.  The version can be enabled/disabled and the context can be a string
  * or null/empty.  It is expected that factories creating the jaxrs servers will honor this enabled flag.
- *
+ *</p>
  * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
  * @since 11 /13/2018
  * @since 0.1
@@ -27,15 +30,15 @@ package com.rba.jaxrs.autoconfig.version;
 public interface ApiVersion {
 
     /**
-     * Gets api version.
+     * Gets the api version context as a string.
      *
      * @return the api version
      */
     String getApiVersion();
 
     /**
-     * Returns if the api version is enabled and should be host by a jaxrs server.
-     * Defaults the True
+     * Returns if the api version is enabled and should be hosted by a jaxrs server.
+     * Defaults to True
      *
      * @return the boolean
      */

--- a/src/test/java/com/rba/jaxrs/autoconfig/classify/EmptyApiContextUTEST.java
+++ b/src/test/java/com/rba/jaxrs/autoconfig/classify/EmptyApiContextUTEST.java
@@ -14,27 +14,29 @@
  * limitations under the License.
  */
 
-package com.rba.jaxrs.autoconfig.version;
+package com.rba.jaxrs.autoconfig.classify;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Runs basic validations to ensure the EmptyApiVersion properly meets the ApiVersion expectations and defaults come through.
+ * Runs basic validations to ensure the {@link EmptyApiContext} properly meets the {@link ApiContext} expectations and defaults
+ * come
+ * through.
  *
  * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
- * @since 11/13/2018
+ * @since 11/14/2018
  */
-class EmptyApiVersionUTEST {
+class EmptyApiContextUTEST {
 
     @Test
-    void validateApiVersion() {
-        Assertions.assertNull(EmptyApiVersion.EMPTY_API_VERSION.getApiVersion(), "The API Version should always be null");
+    void validateApiContext() {
+        Assertions.assertNull(EmptyApiContext.EMPTY_API_CONTEXT.getApiContext(), "The API Context should always be null");
     }
 
     @Test
-    void validateEmptyApiVersionEnabled() {
-        Assertions.assertTrue(EmptyApiVersion.EMPTY_API_VERSION.isApiVersionEnabled(), "This should always be true from the "
-                + "default of the interface");
+    void validateEmptyApiContextEnabled() {
+        Assertions.assertTrue(EmptyApiContext.EMPTY_API_CONTEXT.isApiContextEnabled(), "This should always be true from "
+                + "the default of the interface");
     }
 }


### PR DESCRIPTION
This update includes the ApiContext interface along with a default
empty implementation.  Unit Testing of the default interface to ensure
defaults are not changed.

Updates .gitignore to ignore the out directory from the local gradle build.

Resolves: https://github.com/amutsch/jaxrs-autoconfig/issues/2