### PR TITLE
Adds Scanner capabilities to find RestApiEndpoint annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ ext {
     slf4jApiVersion='1.7.25'
     jaxrsVersion='2.1.1'
     classgraphVersion='4.4.12'
+    springVersion='5.1.2.RELEASE'
 }
 
 //Jar Information
@@ -54,6 +55,9 @@ dependencies {
 
     //Interface finding
     implementation("io.github.classgraph:classgraph:${classgraphVersion}")
+
+    //Spring annotations for component scanning
+    implementation("org.springframework:spring-context:${springVersion}")
 }
 
 test {
@@ -85,9 +89,9 @@ buildScan {
 
 jacocoTestReport {
     reports {
-        xml.enabled true
+        xml.setEnabled(true)
         xml.destination file("${buildDir}/reports/jacoco/report.xml")
-        csv.enabled false
+        csv.setEnabled(false)
         html.destination file("${buildDir}/reports/jacoco/html")
     }
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -138,10 +138,11 @@
     </module>
     <module name="Indentation"/>
     <module name="OverloadMethodsDeclarationOrder"/>
-    <module name="VariableDeclarationUsageDistance"/>
     <module name="CustomImportOrder">
+      <property name="severity" value="ignore"/>
       <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
       <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>
     </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceBefore">

--- a/src/main/java/com/rba/jaxrs/autoconfig/scan/DefaultJaxRsAutoConfigScanner.java
+++ b/src/main/java/com/rba/jaxrs/autoconfig/scan/DefaultJaxRsAutoConfigScanner.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rba.jaxrs.autoconfig.scan;
+
+
+import com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint;
+import com.rba.jaxrs.autoconfig.transform.DefaultRestApiEndpointTransformer;
+import com.rba.jaxrs.autoconfig.transform.EndpointContextContainer;
+import com.rba.jaxrs.autoconfig.transform.RestApiContextTransformer;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * A default implementation of {@link JaxRsAutoConfigScanner} that will properly find all classes containing
+ * {@link RestApiEndpoint} annotations whether they are on spring beans or not.  This class honors all the documentation
+ * of {@link JaxRsAutoConfigScanner} in that it will honor the whitelist and blacklist.  It properly handles the usage of
+ * multiple annotations being present to host a class on multiple endpoints.
+ *
+ * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
+ * @since 11 /20/2018
+ * @since 0.1.0
+ */
+@Component
+public class DefaultJaxRsAutoConfigScanner implements JaxRsAutoConfigScanner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultJaxRsAutoConfigScanner.class);
+
+    //Autowiring not required as it should use the assigned default provided by the auto configuration system
+    @Autowired(required = false)
+    private final RestApiContextTransformer contextTransformer = new DefaultRestApiEndpointTransformer();
+
+    @Override
+    public Map<EndpointContextContainer, List<Class<?>>> getAutoConfigurationData(String... optionalScanPackages) {
+        return getAutoConfigurationData(Arrays.asList(optionalScanPackages));
+    }
+
+    @Override
+    public Map<EndpointContextContainer, List<Class<?>>> getAutoConfigurationData(List<String> optionalScanPackages,
+        String... scanPackageBlackList) {
+        Map<EndpointContextContainer, List<Class<?>>> scannedResults = new HashMap<>();
+        ClassGraph endpointGraph = new ClassGraph().enableAllInfo();
+        if (optionalScanPackages != null && !optionalScanPackages.isEmpty()) {
+            endpointGraph = endpointGraph.whitelistPackages(optionalScanPackages.toArray(new String[]{}));
+        }
+        if (scanPackageBlackList.length > 0) {
+            endpointGraph = endpointGraph.blacklistPackages(scanPackageBlackList);
+        }
+        try (ScanResult scanResult = endpointGraph.scan()) {
+            processAnnotationClass(scanResult, scannedResults, RestApiEndpoint.class.getName());
+            processAnnotationClass(scanResult, scannedResults, RestApiEndpoint.RestApiEndpoints.class.getName());
+        }
+        return scannedResults;
+    }
+
+    /**
+     * This private method allows re-use of the scanResult and proper population of the data map.  The ClassGraph code
+     * does not handle recognition of annotations the same as the jre.  Multiple annotations on the same class does not
+     * get recognized which requires us to Scan for both {@link RestApiEndpoint} and
+     * {@link com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint.RestApiEndpoints} which requires multiple processing of
+     * the data from the scan result.
+     *
+     * @param scanResult An open scanResult from calling the scan method on a ClassGraph
+     * @param scannedResults The Map which is not null that data will be populated into
+     * @param annotationClass The class we are calling an annotation in this process.
+     */
+    private void processAnnotationClass(ScanResult scanResult,
+        Map<EndpointContextContainer, List<Class<?>>> scannedResults, String annotationClass) {
+        try {
+            ClassInfoList restApiClasses = scanResult.getClassesWithAnnotation(annotationClass);
+            for (ClassInfo classData : restApiClasses) {
+                RestApiEndpoint[] apiEndpoints = classData.loadClass().getAnnotationsByType(RestApiEndpoint.class);
+                for (RestApiEndpoint apiEndpoint : apiEndpoints) {
+                    EndpointContextContainer contextContainer = contextTransformer.getEndpointContext(apiEndpoint);
+                    List<Class<?>> apiClasses = scannedResults.get(contextContainer);
+                    if (apiClasses == null) {
+                        apiClasses = new ArrayList<>();
+                        scannedResults.put(contextContainer, apiClasses);
+                    }
+                    apiClasses.add(classData.loadClass());
+                }
+            }
+        } catch (IllegalArgumentException iae) {
+            //The way ClassGraph processing works there are scenarios where the annotations will not be properly found and
+            // throw an exception.  Gracefully handle the exception and processing of the scenarios.  We are knowingly
+            // eating the error and only logging to debug as we will run the process against the wrapping annotation.
+            LOGGER.debug("No classes discovered for annotation: " + annotationClass, iae);
+        }
+    }
+}

--- a/src/main/java/com/rba/jaxrs/autoconfig/scan/JaxRsAutoConfigScanner.java
+++ b/src/main/java/com/rba/jaxrs/autoconfig/scan/JaxRsAutoConfigScanner.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rba.jaxrs.autoconfig.scan;
+
+import com.rba.jaxrs.autoconfig.transform.EndpointContextContainer;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementations of this interface are responsible for finding the classes with
+ * {@link com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint} annotations in the system.  The scanner is also
+ * responsible for running the scanned results through the
+ * {@link com.rba.jaxrs.autoconfig.transform.RestApiContextTransformer}.
+ * The results Map should allow the rest factories to make all the decisions and have all the data necessary for create of
+ * rest apis.
+ *
+ * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
+ * @since 11 /19/2018
+ * @since 0.1.0
+ */
+public interface JaxRsAutoConfigScanner {
+
+    /**
+     * Scans the requested packages for classes annotated with the
+     * {@link com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint}.  The Rest Endpoints should be transformed and return
+     * with their relevant context.
+     *
+     * An Empty map should be returned if no annotations are found.
+     *
+     * @param optionalScanPackages optional application packages to scan
+     * @return the auto configuration data map
+     */
+    Map<EndpointContextContainer, List<Class<?>>> getAutoConfigurationData(String... optionalScanPackages);
+
+    /**
+     * Scans the requested packages for classes annotated with the
+     * {@link com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint}.  The Rest Endpoints should be transformed and return
+     * with their relevant context.  The black list packages will be excluded even if they are a sub package of the
+     * whitelist.
+     *
+     * An Empty map should be returned if no annotations are found.
+     *
+     * @param optionalScanPackages optional application packages to scan
+     * @param scanPackageBlackList optional application packages to blacklist from scanning
+     * @return the auto configuration data map
+     */
+    Map<EndpointContextContainer, List<Class<?>>> getAutoConfigurationData(List<String> optionalScanPackages,
+            String... scanPackageBlackList);
+}

--- a/src/main/java/com/rba/jaxrs/autoconfig/transform/EndpointContextContainer.java
+++ b/src/main/java/com/rba/jaxrs/autoconfig/transform/EndpointContextContainer.java
@@ -16,6 +16,8 @@
 
 package com.rba.jaxrs.autoconfig.transform;
 
+import java.util.Objects;
+
 /**
  * A container for holding the result of context transformation.  This class holds the final context and the indicator of
  * if the context is enabled.  The context will be enabled if {@link com.rba.jaxrs.autoconfig.version.ApiVersion} and all
@@ -58,5 +60,23 @@ public class EndpointContextContainer {
      */
     public boolean isEnabled() {
         return enabled;
+    }
+
+    //Override Equals and Hashcode as we are using this class in a Map Key during the scanning process.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EndpointContextContainer that = (EndpointContextContainer) o;
+        return enabled == that.enabled && Objects.equals(endpointContext, that.endpointContext);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpointContext, enabled);
     }
 }

--- a/src/test/java/com/rba/jaxrs/autoconfig/scan/JaxRsAutoConfigScannerUTEST.java
+++ b/src/test/java/com/rba/jaxrs/autoconfig/scan/JaxRsAutoConfigScannerUTEST.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rba.jaxrs.autoconfig.scan;
+
+import com.rba.jaxrs.autoconfig.exceptions.ContextResolverException;
+import com.rba.jaxrs.autoconfig.scan.stub.StubEndpointWithMultipleAnnotationsForScan;
+import com.rba.jaxrs.autoconfig.stubs.StubEndpointEmptyValuesInAnnotation;
+import com.rba.jaxrs.autoconfig.stubs.StubEndpointWithEmptyAnnotation;
+import com.rba.jaxrs.autoconfig.stubs.StubEndpointWithMultipleAnnotations;
+import com.rba.jaxrs.autoconfig.stubs.StubEndpointWithNullContexts;
+import com.rba.jaxrs.autoconfig.stubs.StubEndpointWithVersionAndMultipleContexts;
+import com.rba.jaxrs.autoconfig.stubs.StubEndpointWithVersionAndSingleContext;
+import com.rba.jaxrs.autoconfig.transform.EndpointContextContainer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
+ * @since 11/19/2018
+ */
+class JaxRsAutoConfigScannerUTEST {
+
+    private final JaxRsAutoConfigScanner scanner = new DefaultJaxRsAutoConfigScanner();
+
+    //This will error due to invalid contexts in the noscan stubs package
+    @Test
+    void verifyAutoConfigScanNoScanBase() {
+        Assertions.assertThrows(ContextResolverException.class,
+            () -> scanner.getAutoConfigurationData());
+    }
+
+    //Verify scanning a package with no annotations in it
+    @Test
+    void verifyAutoConfigScanNoBeansInScanBase() {
+        Map<EndpointContextContainer, List<Class<?>>> results = scanner.getAutoConfigurationData("com.rba.jaxrs.autoconfig"
+            + ".classify");
+        Assertions.assertTrue(results.isEmpty());
+    }
+
+    //Scan a small package that has 1 class with 2 annotations
+    @Test
+    void verifyAutoConfigNarrowScanBase() {
+        Map<EndpointContextContainer, List<Class<?>>> results = scanner.getAutoConfigurationData("com.rba.jaxrs.autoconfig"
+            + ".scan.stub");
+        Map<EndpointContextContainer, List<Class<?>>> expectedResults = createScanPackageResults();
+        validateResults(results, expectedResults);
+    }
+
+    //This will return everything in the project excluding the invalid Rest Annotations
+    @Test
+    void verifyBlacklistOnlyScan() {
+        Map<EndpointContextContainer, List<Class<?>>> results =
+            scanner.getAutoConfigurationData((List<String>)null, "com.rba.jaxrs.autoconfig.stubs.noscan");
+        Map<EndpointContextContainer, List<Class<?>>> expectedResults = createScanPackageResults();
+        expectedResults.putAll(createStubPackageResults());
+        validateResults(results, expectedResults);
+    }
+
+    @Test
+    void verifyCombinedWhitelistAndBlacklistScan() {
+        Map<EndpointContextContainer, List<Class<?>>> results =
+            scanner.getAutoConfigurationData(Collections.singletonList("com.rba.jaxrs.autoconfig.stubs"), "com.rba.jaxrs"
+                + ".autoconfig.stubs.noscan");
+        Map<EndpointContextContainer, List<Class<?>>> expectedResults = createStubPackageResults();
+        validateResults(results, expectedResults);
+    }
+
+    private static Map<EndpointContextContainer, List<Class<?>>> createScanPackageResults() {
+        Map<EndpointContextContainer, List<Class<?>>> expectedResults = new HashMap<>();
+        expectedResults.put(new EndpointContextContainer("/v1/admin", true),
+            Collections.singletonList(StubEndpointWithMultipleAnnotationsForScan.class));
+        expectedResults.put(new EndpointContextContainer("/open", true),
+            Collections.singletonList(StubEndpointWithMultipleAnnotationsForScan.class));
+        return expectedResults;
+    }
+
+    private static Map<EndpointContextContainer, List<Class<?>>> createStubPackageResults() {
+        Map<EndpointContextContainer, List<Class<?>>> expectedResults = new HashMap<>();
+        expectedResults.put(new EndpointContextContainer("/", true),
+            Arrays.asList(StubEndpointEmptyValuesInAnnotation.class,
+                StubEndpointWithEmptyAnnotation.class, StubEndpointWithNullContexts.class));
+        expectedResults.put(new EndpointContextContainer("/v1/open", true),
+            Arrays.asList(StubEndpointWithMultipleAnnotations.class,
+                StubEndpointWithVersionAndSingleContext.class));
+        expectedResults.put(new EndpointContextContainer("/open/testing", false),
+            Collections.singletonList(StubEndpointWithMultipleAnnotations.class));
+        expectedResults.put(new EndpointContextContainer("/v2/open/admin/testing", false),
+            Collections.singletonList(StubEndpointWithVersionAndMultipleContexts.class));
+        return expectedResults;
+    }
+
+    private static void validateResults(Map<EndpointContextContainer, List<Class<?>>> results, Map<EndpointContextContainer,
+        List<Class<?>>> expectedResults) {
+        Assertions.assertEquals(expectedResults.size(), results.size());
+        //Use our expected results to drive the validation.  If there is a difference(missing/different) it will occur in
+        // this block since the size matches.
+        for (Map.Entry<EndpointContextContainer, List<Class<?>>> mapEntry : expectedResults.entrySet()) {
+            Assertions.assertTrue(results.containsKey(mapEntry.getKey()));
+            List<Class<?>> resultClassList = results.get(mapEntry.getKey());
+            List<Class<?>> expectedClassList = mapEntry.getValue();
+            Assertions.assertEquals(expectedClassList.size(), resultClassList.size());
+            for (Class<?> expectedClass : expectedClassList) {
+                Assertions.assertTrue(resultClassList.contains(expectedClass));
+            }
+        }
+    }
+}

--- a/src/test/java/com/rba/jaxrs/autoconfig/scan/stub/StubEndpointWithMultipleAnnotationsForScan.java
+++ b/src/test/java/com/rba/jaxrs/autoconfig/scan/stub/StubEndpointWithMultipleAnnotationsForScan.java
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package com.rba.jaxrs.autoconfig.stubs;
+package com.rba.jaxrs.autoconfig.scan.stub;
 
 import com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint;
 
 /**
  * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
- * @since 11/16/2018
+ * @since 11/14/2018
  */
-@RestApiEndpoint(apiContextEnumNames = {"INVALID_CONTEXT", "ADMIN"})
-public class StubEndpointInvalidContext {
+@RestApiEndpoint(apiVersionEnumName = "EXTERNAL_V1", apiContextEnumNames = "ADMIN")
+@RestApiEndpoint(apiVersionEnumName = "INTERNAL", apiContextEnumNames = {"OPEN"})
+public class StubEndpointWithMultipleAnnotationsForScan {
+    //Empty class, annotation testing
 }

--- a/src/test/java/com/rba/jaxrs/autoconfig/stubs/noscan/StubEndpointInvalidContext.java
+++ b/src/test/java/com/rba/jaxrs/autoconfig/stubs/noscan/StubEndpointInvalidContext.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rba.jaxrs.autoconfig.stubs.noscan;
+
+import com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint;
+
+/**
+ * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
+ * @since 11/16/2018
+ */
+@RestApiEndpoint(apiContextEnumNames = {"INVALID_CONTEXT", "ADMIN"})
+public class StubEndpointInvalidContext {
+}

--- a/src/test/java/com/rba/jaxrs/autoconfig/stubs/noscan/StubEndpointInvalidVersion.java
+++ b/src/test/java/com/rba/jaxrs/autoconfig/stubs/noscan/StubEndpointInvalidVersion.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.rba.jaxrs.autoconfig.stubs;
+package com.rba.jaxrs.autoconfig.stubs.noscan;
 
 import com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint;
 

--- a/src/test/java/com/rba/jaxrs/autoconfig/transform/DefaultRestApiEndpointTransformerUTEST.java
+++ b/src/test/java/com/rba/jaxrs/autoconfig/transform/DefaultRestApiEndpointTransformerUTEST.java
@@ -18,8 +18,8 @@ package com.rba.jaxrs.autoconfig.transform;
 
 import com.rba.jaxrs.autoconfig.annotations.RestApiEndpoint;
 import com.rba.jaxrs.autoconfig.exceptions.ContextResolverException;
-import com.rba.jaxrs.autoconfig.stubs.StubEndpointInvalidContext;
-import com.rba.jaxrs.autoconfig.stubs.StubEndpointInvalidVersion;
+import com.rba.jaxrs.autoconfig.stubs.noscan.StubEndpointInvalidContext;
+import com.rba.jaxrs.autoconfig.stubs.noscan.StubEndpointInvalidVersion;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/rba/jaxrs/autoconfig/transform/EndpointContextContainerUTEST.java
+++ b/src/test/java/com/rba/jaxrs/autoconfig/transform/EndpointContextContainerUTEST.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rba.jaxrs.autoconfig.transform;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author AUtsch - Adam Utsch - adam.utsch@rbaconsulting.com
+ * @since 11/20/2018
+ */
+public class EndpointContextContainerUTEST {
+
+    @Test
+    void nullCompareCheck() {
+        Assertions.assertFalse(new EndpointContextContainer("/", false).equals(null));
+    }
+
+    @Test
+    void sameItemCheck() {
+        EndpointContextContainer container = new EndpointContextContainer("/", true);
+        Assertions.assertTrue(container.equals(container));
+    }
+
+    @Test
+    void differentEnabledFlag() {
+        EndpointContextContainer container1 = new EndpointContextContainer("/", true);
+        EndpointContextContainer container2 = new EndpointContextContainer("/", false);
+        Assertions.assertFalse(container1.equals(container2));
+    }
+
+    @Test
+    void differentContextAddress() {
+        EndpointContextContainer container1 = new EndpointContextContainer("/", true);
+        EndpointContextContainer container2 = new EndpointContextContainer("/v1", true);
+        Assertions.assertFalse(container1.equals(container2));
+    }
+
+    @Test
+    void differentItemSameDetails() {
+        EndpointContextContainer container1 = new EndpointContextContainer("/v1", true);
+        EndpointContextContainer container2 = new EndpointContextContainer("/v1", true);
+        Assertions.assertTrue(container1.equals(container2));
+        Assertions.assertEquals(container1.hashCode(), container2.hashCode());
+    }
+
+    @Test
+    void differentClassCheck() {
+        EndpointContextContainer container1 = new EndpointContextContainer("/v1", true);
+        Assertions.assertFalse(container1.equals("String Data Compare"));
+    }
+}


### PR DESCRIPTION
Adds interfaces and a default scanner to find the RestApiEndpoints in the system
and transform them via the Default Transformer that currently exists in the system.
The transformer is autowired in case the user doesn't want to use the default
transformer.

Adds functional tests to verify the functionality based on the default scanner processing
data using the default transformer.

Resolves: https://github.com/amutsch/jaxrs-autoconfig/issues/7